### PR TITLE
set this.winbox to null after close

### DIFF
--- a/packages/lib/src/components/VueWinBox.ts
+++ b/packages/lib/src/components/VueWinBox.ts
@@ -64,6 +64,7 @@ export default defineComponent({
                 onclose: () => {
                     this.$emit('onclose', { id: this.winbox?.id })
                     this.initialized = false
+                    this.winbox = null
                     return false
                 },
                 onfocus: () => {


### PR DESCRIPTION
Set this.winbox to null after close, otherwise it will crash when unmount a closed window.